### PR TITLE
オブジェクト生成時のパラメータにデフォルト値を設定する

### DIFF
--- a/pynanacolight/core.py
+++ b/pynanacolight/core.py
@@ -10,8 +10,10 @@ from requests import session
 
 
 class PyNanacoLight:
-    def __init__(self, session: session()):
-        self._session = session
+    def __init__(self, _session: session()=None):
+        if _session is None:
+            _session = session()
+        self._session = _session
 
         self._html = None
 


### PR DESCRIPTION
PyNanacoLightのオブジェクトを生成する側で*requests.session()*を作って渡すようになっていますが、PyNanacoLight側で作るようにしてみました。

before

```python
import requests
nanaco = PyNanacoLight(requests.session())
```

after

```python
nanaco = PyNanacoLight()
```
